### PR TITLE
feat : serverside pagination/filter

### DIFF
--- a/src/apis/generated/board-controller/board-controller.ts
+++ b/src/apis/generated/board-controller/board-controller.ts
@@ -24,8 +24,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoListBoard,
-  ApiRespDtoVoid,
   BoardCreateReqDto
 } from '../openAPIDefinition.schemas';
 
@@ -41,7 +39,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type getBoardListResponse200 = {
-  data: ApiRespDtoListBoard
+  data: Blob
   status: 200
 }
     
@@ -145,7 +143,7 @@ export function useGetBoardList<TData = Awaited<ReturnType<typeof getBoardList>>
 
 
 export type addBoardResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -221,7 +219,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddBoardMutationOptions(options), queryClient);
     }
     export type removeBoardResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/bookmark-controller/bookmark-controller.ts
+++ b/src/apis/generated/bookmark-controller/bookmark-controller.ts
@@ -23,12 +23,6 @@ import type {
   UseQueryResult
 } from '@tanstack/react-query';
 
-import type {
-  ApiRespDtoBoolean,
-  ApiRespDtoListBookmarkRespDto,
-  ApiRespDtoVoid
-} from '../openAPIDefinition.schemas';
-
 import { customInstance } from '../../custom-instance';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -41,7 +35,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type existsByRecipeIdResponse200 = {
-  data: ApiRespDtoBoolean
+  data: Blob
   status: 200
 }
     
@@ -145,7 +139,7 @@ export function useExistsByRecipeId<TData = Awaited<ReturnType<typeof existsByRe
 
 
 export type addBookmarkResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -220,7 +214,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddBookmarkMutationOptions(options), queryClient);
     }
     export type deleteBookmarkResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -295,7 +289,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getDeleteBookmarkMutationOptions(options), queryClient);
     }
     export type getBookmarkListByUserIdResponse200 = {
-  data: ApiRespDtoListBookmarkRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/comment-controller/comment-controller.ts
+++ b/src/apis/generated/comment-controller/comment-controller.ts
@@ -24,10 +24,7 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  AddCommentReqDto,
-  ApiRespDtoComment,
-  ApiRespDtoListCommentRespDto,
-  ApiRespDtoVoid
+  AddCommentReqDto
 } from '../openAPIDefinition.schemas';
 
 import { customInstance } from '../../custom-instance';
@@ -42,7 +39,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type addRecipeCommentResponse200 = {
-  data: ApiRespDtoComment
+  data: Blob
   status: 200
 }
     
@@ -119,7 +116,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddRecipeCommentMutationOptions(options), queryClient);
     }
     export type addPostCommentResponse200 = {
-  data: ApiRespDtoComment
+  data: Blob
   status: 200
 }
     
@@ -196,7 +193,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddPostCommentMutationOptions(options), queryClient);
     }
     export type getMyCommentListResponse200 = {
-  data: ApiRespDtoListCommentRespDto
+  data: Blob
   status: 200
 }
     
@@ -300,7 +297,7 @@ export function useGetMyCommentList<TData = Awaited<ReturnType<typeof getMyComme
 
 
 export type getRecipeCommentListByTargetResponse200 = {
-  data: ApiRespDtoListCommentRespDto
+  data: Blob
   status: 200
 }
     
@@ -404,7 +401,7 @@ export function useGetRecipeCommentListByTarget<TData = Awaited<ReturnType<typeo
 
 
 export type getPostCommentListByTargetResponse200 = {
-  data: ApiRespDtoListCommentRespDto
+  data: Blob
   status: 200
 }
     
@@ -508,7 +505,7 @@ export function useGetPostCommentListByTarget<TData = Awaited<ReturnType<typeof 
 
 
 export type deleteCommentResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/follow-controller/follow-controller.ts
+++ b/src/apis/generated/follow-controller/follow-controller.ts
@@ -23,13 +23,6 @@ import type {
   UseQueryResult
 } from '@tanstack/react-query';
 
-import type {
-  ApiRespDtoFollowCountRespDto,
-  ApiRespDtoFollowStatusRespDto,
-  ApiRespDtoListFollowRespDto,
-  ApiRespDtoVoid
-} from '../openAPIDefinition.schemas';
-
 import { customInstance } from '../../custom-instance';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -42,7 +35,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type followResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -117,7 +110,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getFollowMutationOptions(options), queryClient);
     }
     export type unfollowResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -192,7 +185,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getUnfollowMutationOptions(options), queryClient);
     }
     export type getFollowStatusResponse200 = {
-  data: ApiRespDtoFollowStatusRespDto
+  data: Blob
   status: 200
 }
     
@@ -296,7 +289,7 @@ export function useGetFollowStatus<TData = Awaited<ReturnType<typeof getFollowSt
 
 
 export type getFollowingsResponse200 = {
-  data: ApiRespDtoListFollowRespDto
+  data: Blob
   status: 200
 }
     
@@ -400,7 +393,7 @@ export function useGetFollowings<TData = Awaited<ReturnType<typeof getFollowings
 
 
 export type getFollowersResponse200 = {
-  data: ApiRespDtoListFollowRespDto
+  data: Blob
   status: 200
 }
     
@@ -504,7 +497,7 @@ export function useGetFollowers<TData = Awaited<ReturnType<typeof getFollowers>>
 
 
 export type getFollowCountResponse200 = {
-  data: ApiRespDtoFollowCountRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/mail-controller/mail-controller.ts
+++ b/src/apis/generated/mail-controller/mail-controller.ts
@@ -14,10 +14,6 @@ import type {
   UseMutationResult
 } from '@tanstack/react-query';
 
-import type {
-  ApiRespDtoVoid
-} from '../openAPIDefinition.schemas';
-
 import { customInstance } from '../../custom-instance';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -30,7 +26,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type sendMailResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/manage-controller/manage-controller.ts
+++ b/src/apis/generated/manage-controller/manage-controller.ts
@@ -19,11 +19,6 @@ import type {
   UseQueryResult
 } from '@tanstack/react-query';
 
-import type {
-  ApiRespDtoListUser,
-  ApiRespDtoUser
-} from '../openAPIDefinition.schemas';
-
 import { customInstance } from '../../custom-instance';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -36,7 +31,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type getUserByUsernameResponse200 = {
-  data: ApiRespDtoUser
+  data: Blob
   status: 200
 }
     
@@ -140,7 +135,7 @@ export function useGetUserByUsername<TData = Awaited<ReturnType<typeof getUserBy
 
 
 export type getUserListResponse200 = {
-  data: ApiRespDtoListUser
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/notification-controller/notification-controller.ts
+++ b/src/apis/generated/notification-controller/notification-controller.ts
@@ -24,9 +24,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoInteger,
-  ApiRespDtoListNotificationRespDto,
-  ApiRespDtoVoid,
   GetNotificationsParams
 } from '../openAPIDefinition.schemas';
 
@@ -42,7 +39,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type markAsReadResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -117,7 +114,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getMarkAsReadMutationOptions(options), queryClient);
     }
     export type markAllAsReadResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -192,7 +189,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getMarkAllAsReadMutationOptions(options), queryClient);
     }
     export type getNotificationsResponse200 = {
-  data: ApiRespDtoListNotificationRespDto
+  data: Blob
   status: 200
 }
     
@@ -303,7 +300,7 @@ export function useGetNotifications<TData = Awaited<ReturnType<typeof getNotific
 
 
 export type getUnreadCountResponse200 = {
-  data: ApiRespDtoInteger
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/o-auth-2-auth-controller/o-auth-2-auth-controller.ts
+++ b/src/apis/generated/o-auth-2-auth-controller/o-auth-2-auth-controller.ts
@@ -15,7 +15,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoVoid,
   OAuth2MergeReqDto,
   OAuth2SignupReqDto
 } from '../openAPIDefinition.schemas';
@@ -32,7 +31,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type signup1Response200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -108,7 +107,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getSignup1MutationOptions(options), queryClient);
     }
     export type mergeResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/openAPIDefinition.schemas.ts
+++ b/src/apis/generated/openAPIDefinition.schemas.ts
@@ -153,25 +153,6 @@ export interface ApiRespDtoInteger {
   data?: number;
 }
 
-export interface AiHashtagReqDto {
-  title?: string;
-  intro?: string;
-  ingredients?: string;
-  steps?: string;
-  limit?: number;
-}
-
-export interface AiHashtagRespDto {
-  hashtags?: string[];
-}
-
-export interface ApiRespDtoAiHashtagRespDto {
-  status?: string;
-  message?: string;
-  /** 응답 데이터(없으면 null) */
-  data?: AiHashtagRespDto;
-}
-
 export interface UserProfileRespDto {
   userId?: number;
   username?: string;
@@ -216,8 +197,8 @@ export interface PrincipalUser {
   userRoles?: UserRole[];
   authorities?: GrantedAuthority[];
   enabled?: boolean;
-  credentialsNonExpired?: boolean;
   accountNonExpired?: boolean;
+  credentialsNonExpired?: boolean;
   accountNonLocked?: boolean;
 }
 
@@ -387,6 +368,12 @@ export interface ApiRespDtoListBoard {
   data?: Board[];
 }
 
+export interface RecipeFilterReqDto {
+  mainCategoryId?: number;
+  subCategoryId?: number;
+  keyword?: string;
+}
+
 export interface RecipeDetailRespDto {
   recipeId?: number;
   boardId?: number;
@@ -468,5 +455,11 @@ mode?: string;
 export type GetRecipeListParams = {
 page?: number;
 size?: number;
+};
+
+export type GetFilteredRecipeListParams = {
+page?: number;
+size?: number;
+recipeFilterReqDto: RecipeFilterReqDto;
 };
 

--- a/src/apis/generated/rating-controller/rating-controller.ts
+++ b/src/apis/generated/rating-controller/rating-controller.ts
@@ -24,9 +24,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoRatingSummaryRespDto,
-  ApiRespDtoRecipeRatingRespDto,
-  ApiRespDtoVoid,
   UpsertRatingReqDto
 } from '../openAPIDefinition.schemas';
 
@@ -42,7 +39,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type upsertRatingResponse200 = {
-  data: ApiRespDtoRecipeRatingRespDto
+  data: Blob
   status: 200
 }
     
@@ -118,7 +115,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getUpsertRatingMutationOptions(options), queryClient);
     }
     export type deleteRatingResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -193,7 +190,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getDeleteRatingMutationOptions(options), queryClient);
     }
     export type getSummaryResponse200 = {
-  data: ApiRespDtoRatingSummaryRespDto
+  data: Blob
   status: 200
 }
     
@@ -297,7 +294,7 @@ export function useGetSummary<TData = Awaited<ReturnType<typeof getSummary>>, TE
 
 
 export type getRatingResponse200 = {
-  data: ApiRespDtoRecipeRatingRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/recipe-controller/recipe-controller.ts
+++ b/src/apis/generated/recipe-controller/recipe-controller.ts
@@ -25,10 +25,7 @@ import type {
 
 import type {
   AddRecipeReqDto,
-  ApiRespDtoInteger,
-  ApiRespDtoRecipeDetailRespDto,
-  ApiRespDtoRecipeListPageRespDto,
-  ApiRespDtoVoid,
+  GetFilteredRecipeListParams,
   GetRecipeListParams,
   ModifyRecipeReqDto
 } from '../openAPIDefinition.schemas';
@@ -45,7 +42,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type modifyRecipeResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -124,7 +121,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getModifyRecipeMutationOptions(options), queryClient);
     }
     export type addRecipeResponse200 = {
-  data: ApiRespDtoInteger
+  data: Blob
   status: 200
 }
     
@@ -201,7 +198,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddRecipeMutationOptions(options), queryClient);
     }
     export type getRecipeListResponse200 = {
-  data: ApiRespDtoRecipeListPageRespDto
+  data: Blob
   status: 200
 }
     
@@ -319,8 +316,127 @@ export function useGetRecipeList<TData = Awaited<ReturnType<typeof getRecipeList
 
 
 
+export type getFilteredRecipeListResponse200 = {
+  data: Blob
+  status: 200
+}
+    
+export type getFilteredRecipeListResponseSuccess = (getFilteredRecipeListResponse200) & {
+  headers: Headers;
+};
+;
+
+export type getFilteredRecipeListResponse = (getFilteredRecipeListResponseSuccess)
+
+export const getGetFilteredRecipeListUrl = (boardId: number,
+    params: GetFilteredRecipeListParams,) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0 ? `/board/${boardId}/recipes/list/filtered?${stringifiedParams}` : `/board/${boardId}/recipes/list/filtered`
+}
+
+export const getFilteredRecipeList = async (boardId: number,
+    params: GetFilteredRecipeListParams, options?: RequestInit): Promise<getFilteredRecipeListResponse> => {
+  
+  return customInstance<getFilteredRecipeListResponse>(getGetFilteredRecipeListUrl(boardId,params),
+  {      
+    ...options,
+    method: 'GET'
+    
+    
+  }
+);}
+
+
+
+
+
+export const getGetFilteredRecipeListQueryKey = (boardId: number,
+    params?: GetFilteredRecipeListParams,) => {
+    return [
+    `/board/${boardId}/recipes/list/filtered`, ...(params ? [params] : [])
+    ] as const;
+    }
+
+    
+export const getGetFilteredRecipeListQueryOptions = <TData = Awaited<ReturnType<typeof getFilteredRecipeList>>, TError = unknown>(boardId: number,
+    params: GetFilteredRecipeListParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
+) => {
+
+const {query: queryOptions, request: requestOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getGetFilteredRecipeListQueryKey(boardId,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getFilteredRecipeList>>> = ({ signal }) => getFilteredRecipeList(boardId,params, { signal, ...requestOptions });
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(boardId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GetFilteredRecipeListQueryResult = NonNullable<Awaited<ReturnType<typeof getFilteredRecipeList>>>
+export type GetFilteredRecipeListQueryError = unknown
+
+
+export function useGetFilteredRecipeList<TData = Awaited<ReturnType<typeof getFilteredRecipeList>>, TError = unknown>(
+ boardId: number,
+    params: GetFilteredRecipeListParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getFilteredRecipeList>>,
+          TError,
+          Awaited<ReturnType<typeof getFilteredRecipeList>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof customInstance>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetFilteredRecipeList<TData = Awaited<ReturnType<typeof getFilteredRecipeList>>, TError = unknown>(
+ boardId: number,
+    params: GetFilteredRecipeListParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getFilteredRecipeList>>,
+          TError,
+          Awaited<ReturnType<typeof getFilteredRecipeList>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof customInstance>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetFilteredRecipeList<TData = Awaited<ReturnType<typeof getFilteredRecipeList>>, TError = unknown>(
+ boardId: number,
+    params: GetFilteredRecipeListParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useGetFilteredRecipeList<TData = Awaited<ReturnType<typeof getFilteredRecipeList>>, TError = unknown>(
+ boardId: number,
+    params: GetFilteredRecipeListParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getFilteredRecipeList>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getGetFilteredRecipeListQueryOptions(boardId,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+
+
+
 export type getRecipeDetailResponse200 = {
-  data: ApiRespDtoRecipeDetailRespDto
+  data: Blob
   status: 200
 }
     
@@ -432,7 +548,7 @@ export function useGetRecipeDetail<TData = Awaited<ReturnType<typeof getRecipeDe
 
 
 export type removeRecipeResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/recipe-hashtag-controller/recipe-hashtag-controller.ts
+++ b/src/apis/generated/recipe-hashtag-controller/recipe-hashtag-controller.ts
@@ -25,7 +25,6 @@ import type {
 
 import type {
   AddRecipeHashtagsReqDto,
-  ApiRespDtoListHashtagRespDto,
   SearchHashtagsParams
 } from '../openAPIDefinition.schemas';
 
@@ -41,7 +40,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type addRecipeHashtagsResponse200 = {
-  data: ApiRespDtoListHashtagRespDto
+  data: Blob
   status: 200
 }
     
@@ -117,7 +116,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getAddRecipeHashtagsMutationOptions(options), queryClient);
     }
     export type searchHashtagsResponse200 = {
-  data: ApiRespDtoListHashtagRespDto
+  data: Blob
   status: 200
 }
     
@@ -228,7 +227,7 @@ export function useSearchHashtags<TData = Awaited<ReturnType<typeof searchHashta
 
 
 export type getHashtagsByRecipeIdResponse200 = {
-  data: ApiRespDtoListHashtagRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/user-account-controller/user-account-controller.ts
+++ b/src/apis/generated/user-account-controller/user-account-controller.ts
@@ -24,8 +24,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoPrincipalUser,
-  ApiRespDtoVoid,
   ChangePasswordReqDto,
   ChangeProfileImgReqDto,
   ChangeUsernameReqDto
@@ -43,7 +41,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type withdrawResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -118,7 +116,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getWithdrawMutationOptions(options), queryClient);
     }
     export type changeUsernameResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -194,7 +192,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getChangeUsernameMutationOptions(options), queryClient);
     }
     export type changeProfileImgResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -270,7 +268,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getChangeProfileImgMutationOptions(options), queryClient);
     }
     export type changePasswordResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -346,7 +344,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getChangePasswordMutationOptions(options), queryClient);
     }
     export type getPrincipalResponse200 = {
-  data: ApiRespDtoPrincipalUser
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/user-auth-controller/user-auth-controller.ts
+++ b/src/apis/generated/user-auth-controller/user-auth-controller.ts
@@ -15,8 +15,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoString,
-  ApiRespDtoVoid,
   SigninReqDto,
   SignupReqDto
 } from '../openAPIDefinition.schemas';
@@ -33,7 +31,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type signupResponse200 = {
-  data: ApiRespDtoVoid
+  data: Blob
   status: 200
 }
     
@@ -109,7 +107,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
       return useMutation(getSignupMutationOptions(options), queryClient);
     }
     export type signinResponse200 = {
-  data: ApiRespDtoString
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/user-profile-controller/user-profile-controller.ts
+++ b/src/apis/generated/user-profile-controller/user-profile-controller.ts
@@ -19,10 +19,6 @@ import type {
   UseQueryResult
 } from '@tanstack/react-query';
 
-import type {
-  ApiRespDtoUserProfileRespDto
-} from '../openAPIDefinition.schemas';
-
 import { customInstance } from '../../custom-instance';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -35,7 +31,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type getUserProfileResponse200 = {
-  data: ApiRespDtoUserProfileRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/apis/generated/user-recipe-controller/user-recipe-controller.ts
+++ b/src/apis/generated/user-recipe-controller/user-recipe-controller.ts
@@ -20,7 +20,6 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ApiRespDtoRecipeListPageRespDto,
   GetMyRecipeListParams,
   GetRecipeListByUserIdParams
 } from '../openAPIDefinition.schemas';
@@ -37,7 +36,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export type getRecipeListByUserIdResponse200 = {
-  data: ApiRespDtoRecipeListPageRespDto
+  data: Blob
   status: 200
 }
     
@@ -156,7 +155,7 @@ export function useGetRecipeListByUserId<TData = Awaited<ReturnType<typeof getRe
 
 
 export type getMyRecipeListResponse200 = {
-  data: ApiRespDtoRecipeListPageRespDto
+  data: Blob
   status: 200
 }
     

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+// src/hooks/useDebounce.ts
+import { useState, useEffect } from 'react';
+
+// value: 감시할 값 (검색어), delay: 기다릴 시간 (밀리초)
+export function useDebounce<T>(value: T, delay: number = 500): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    useEffect(() => {
+        // 1. delay 시간이 지나면 값을 업데이트하도록 타이머 설정
+        const timer = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        // 2. 만약 delay 시간이 지나기 전에 value가 또 바뀌면?
+        //    기존 타이머를 취소(clear)해버림! -> 리셋 효과
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+}

--- a/src/layout/RootLayout.jsx
+++ b/src/layout/RootLayout.jsx
@@ -45,7 +45,7 @@ export default function RootLayout() {
 
     const handleNavigate = (pageKey) => {
         if (pageKey === 'home') navigate('/');
-        if (pageKey === 'board') navigate('/boards/1/recipe');
+        if (pageKey === 'board') navigate('/boards/1/recipe/filtered');
         if (pageKey === 'community') navigate('/boards/2/free');
         if (pageKey === 'profile') {
             if (isAdmin(principal)) {
@@ -57,7 +57,7 @@ export default function RootLayout() {
         if (pageKey === 'write') navigate('/boards/1/recipe/write');
     };
 
-    const username = principal?.username || principal?.nickname || '';
+    const username = principal?.username || '';
 
     const handleNotificationClick = (notification) => {
         const raw = notification?.raw ?? {};

--- a/src/pages/home/home-page/HomePage.jsx
+++ b/src/pages/home/home-page/HomePage.jsx
@@ -58,8 +58,7 @@ export default function HomePage() {
         }
     };
 
-    // TODO: 페이지네이션 처리가 필요하다면 params 추가 (현재는 전체/기본 조회)
-    // boardId는 필수 파라미터입니다.
+    // Use original getRecipeList but with default pagination to avoid 500 or NPE in backend
     const { data: recipeListResponse, isLoading } = useGetRecipeList(boardId);
 
     // API 응답 구조: data.data.data.items 배열로 가정

--- a/src/routers/RecipeRouter.jsx
+++ b/src/routers/RecipeRouter.jsx
@@ -8,7 +8,7 @@ export default function RecipeRouter() {
     return (
         <Routes>
             {/* /boards/:boardId/recipe */}
-            <Route path="" element={<RecipeListPage />} />
+            <Route path="filtered" element={<RecipeListPage />} />
             <Route path="write" element={<RecipeWritePage />} />
             <Route path=":recipeId/edit" element={<RecipeEditPage />} />
             <Route path=":recipeId" element={<RecipeDetailPage />} />


### PR DESCRIPTION
기존 클라이언트사이드 페이지네이션 (전체 리스트를 조회한 후 자바스크립트 filter 로직)
변경 서버사이드 페이지네이션 (프론트엔드에서 조건을 백엔드에 넘겨주면 백엔드에서 필터/페이지네이션 된 리스트를 프론트엔드로 돌려줌)

debounce 기법 추가 (0.5초 딜레이 - 추후 변경 가능)